### PR TITLE
tasks/69-gcov_read_IID_from_config. Функционал чтения IID модуля из config.ini

### DIFF
--- a/test_robot_module.cpp
+++ b/test_robot_module.cpp
@@ -131,11 +131,6 @@ TestRobotModule::TestRobotModule() : IID("RCT.Test_robot_module_v107") {
     robot_functions[function_id] =
         new FunctionData(function_id + 1, 1, pt, "debug");
     function_id++;
-
-    robot_functions[function_id] =
-        new FunctionData(function_id + 1, 0, NULL, "get_iid");
-    function_id++;
-
   }
   {
     robot_axis = new AxisData *[COUNT_AXIS];

--- a/test_robot_module.cpp
+++ b/test_robot_module.cpp
@@ -35,10 +35,7 @@ const unsigned int COUNT_AXIS = 3;
   robot_axis[axis_id]->name = AXIS_NAME;                    \
   ++axis_id;
 
-const char *myiid;
-
 TestRobotModule::TestRobotModule() : IID("RCT.Test_robot_module_v107") {
-  myiid = IID.c_str();
   std::string ConfigPath = "";
 #ifdef _WIN32
   WCHAR DllPath[MAX_PATH] = {0};
@@ -256,7 +253,6 @@ void TestRobotModule::final() {
 int TestRobotModule::endProgram(int run_index) { return 0; }
 
 void TestRobotModule::destroy() {
-  colorPrintf(ConsoleColor(ConsoleColor::aqua), "destroy() method called\n");
 #if MODULE_API_VERSION > 000
   delete mi;
 #endif

--- a/test_robot_module.cpp
+++ b/test_robot_module.cpp
@@ -79,7 +79,7 @@ TestRobotModule::TestRobotModule() : IID("RCT.Test_robot_module_v107") {
 
 #if MODULE_API_VERSION > 000
   mi = new ModuleInfo;
-  mi->uid = IID.c_str();
+  mi->uid = const_cast<char*>(IID.c_str());
   mi->mode = ModuleInfo::Modes::PROD;
   mi->version = BUILD_NUMBER;
   mi->digest = NULL;

--- a/test_robot_module.cpp
+++ b/test_robot_module.cpp
@@ -82,7 +82,7 @@ TestRobotModule::TestRobotModule() {
 
 #if MODULE_API_VERSION > 000
   mi = new ModuleInfo;
-  char *IID = new char[string_IID.length() + 1];
+  char IID[string_IID.length() + 1];
   strcpy(IID, string_IID.c_str());
   mi->uid = IID;
   mi->mode = ModuleInfo::Modes::PROD;

--- a/test_robot_module.cpp
+++ b/test_robot_module.cpp
@@ -19,14 +19,12 @@
 
 /* GLOBALS CONFIG */
 
-//#define IID "RCT.Test_robot_module_v107"
-
 #ifdef _WIN32
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #endif
 
-const unsigned int COUNT_ROBOTS = 3;
-const unsigned int COUNT_FUNCTIONS = 8;
+const unsigned int COUNT_ROBOTS = 99;
+const unsigned int COUNT_FUNCTIONS = 7;
 const unsigned int COUNT_AXIS = 3;
 
 #define ADD_ROBOT_AXIS(AXIS_NAME, UPPER_VALUE, LOWER_VALUE) \
@@ -37,10 +35,9 @@ const unsigned int COUNT_AXIS = 3;
   robot_axis[axis_id]->name = AXIS_NAME;                    \
   ++axis_id;
 
-
 const char *myiid;
 
-TestRobotModule::TestRobotModule() : IID("RCT.Test_robot_module_v107_1") {
+TestRobotModule::TestRobotModule() : IID("RCT.Test_robot_module_v107") {
   myiid = IID.c_str();
   std::string ConfigPath = "";
 #ifdef _WIN32
@@ -369,10 +366,6 @@ FunctionResult *TestRobot::executeFunction(CommandMode mode,
     case 7: {  // debug
       const char *tmp = (const char *)args[0];
       colorPrintf(ConsoleColor(ConsoleColor::white), "%s", tmp);
-      break;
-    }
-    case 8: {  // get_iid
-      colorPrintf(ConsoleColor(ConsoleColor::white), "my IID: %s", myiid);
       break;
     }
     default:

--- a/test_robot_module.h
+++ b/test_robot_module.h
@@ -1,6 +1,8 @@
 #ifndef TEST_ROBOT_MODULE_H
 #define TEST_ROBOT_MODULE_H
 
+#include <string>
+
 class TestRobotModule;
 
 class TestRobot : public Robot {
@@ -31,6 +33,8 @@ class TestRobotModule : public RobotModule {
   FunctionData **robot_functions;
   AxisData **robot_axis;
   colorPrintfModuleVA_t *colorPrintf_p;
+
+  std::string IID;
 
 #if MODULE_API_VERSION > 000
   ModuleInfo *mi;


### PR DESCRIPTION
Если конфигурационного файла нет, то присваивается IID по умолчанию.
