### PR TITLE
254-оживление-jenkins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ set_property(TARGET ${PROJECT} PROPERTY CXX_STANDARD 11)
 
 target_compile_options(${PROJECT} PRIVATE
   -Wall -Werror
-  -pedantic
   -fno-strict-aliasing
   $<$<BOOL:API_VERSION LESS 101>:-Wno-write-strings>
 )

--- a/src/test_robot_module.cpp
+++ b/src/test_robot_module.cpp
@@ -3,6 +3,12 @@
 #include <vector>
 
 #include "mystring.h"
+
+#if MODULE_API_VERSION  < 100
+  #include <cstdarg>
+  #include <cstddef>
+#endif
+
 #include "module.h"
 #include "robot_module.h"
 #include "test_robot_module.h"
@@ -15,8 +21,6 @@
 #else
   #include <stdint.h>
   #include <unistd.h>
-  #include <cstdarg>
-  #include <cstddef>
   #include <fcntl.h>
   #include <dlfcn.h>
 #endif


### PR DESCRIPTION
Убрал -pedantic - чтобы на линуксе не падала ошибка из-за приведения указателя на функцию к void*
Поправил инклуды va_list